### PR TITLE
Refresh remote repository cache during browse

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,9 @@ set shell := ["bash", "-cu"]
 
 default: server
 
-# Run the forge server with a SQLite root directory (defaults to ./.forge/db).
-server FORGE_DB_PATH='./.forge/db':
+# Run the forge server with configurable SQLite and repository roots.
+server FORGE_DB_PATH='./.forge/db' FORGE_REPOS_PATH='./.forge/repos':
     mkdir -p {{FORGE_DB_PATH}}
-    FORGE_DB_PATH={{FORGE_DB_PATH}} cargo run --manifest-path server/Cargo.toml --bin server
+    mkdir -p {{FORGE_REPOS_PATH}}
+    FORGE_DB_PATH={{FORGE_DB_PATH}} FORGE_REPOS_PATH={{FORGE_REPOS_PATH}} \
+        cargo run --manifest-path server/Cargo.toml --bin server

--- a/docs/prds/0001-single-user-forge-api.md
+++ b/docs/prds/0001-single-user-forge-api.md
@@ -27,6 +27,7 @@ The forge owner needs a lightweight server that exposes a stable API for managin
 
 ## Functional Requirements
 - Environment variable `FORGE_DB_PATH` points to the directory containing `forge.db` and per-repository databases.
+- Environment variable `FORGE_REPOS_PATH` points to the root directory where working copies of repositories are stored.
 - GraphQL schema exposes `Group` and `Repository` types with fields: `id`, `slug`, and parent references per RFC-0001.
 - Queries: `getAllGroups`, `getAllRepositories`, `getGroup(path: String!)`, `getRepository(path: String!)`.
 - Mutations: `createGroup(input: { slug, parentId? })`, `createRepository(input: { slug, groupId? })`.

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -346,6 +346,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -741,6 +743,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "handlebars"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1070,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1114,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1151,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1328,6 +1395,24 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1790,6 +1875,7 @@ dependencies = [
  "async-graphql-axum",
  "axum",
  "cuid2",
+ "git2",
  "sqlx",
  "tokio",
  "tower-http",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,3 +13,4 @@ sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite", "macros"
 cuid2 = "0.1"
 tower-http = { version = "0.5", features = ["cors"] }
 url = "2"
+git2 = { version = "0.18", features = ["https"] }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -8,7 +8,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, S
 const FORGE_DB_FILENAME: &str = "forge.db";
 
 /// Initialize the forge metadata database, running migrations as needed.
-pub async fn init_pool() -> Result<SqlitePool> {
+pub async fn init_pool() -> Result<(SqlitePool, PathBuf)> {
     let db_root =
         std::env::var("FORGE_DB_PATH").context("FORGE_DB_PATH environment variable must be set")?;
 
@@ -32,10 +32,10 @@ pub async fn init_pool() -> Result<SqlitePool> {
 
     sqlx::migrate!("./migrations").run(&pool).await?;
 
-    Ok(pool)
+    Ok((pool, db_root_path))
 }
 
-fn normalize_path<P: Into<PathBuf>>(path: P) -> Result<PathBuf> {
+pub(crate) fn normalize_path<P: Into<PathBuf>>(path: P) -> Result<PathBuf> {
     let path = path.into();
     if path.is_absolute() {
         return Ok(path);


### PR DESCRIPTION
## Summary
- refresh remote repository caches before listing contents so linked repositories stay up to date
- update cached HEAD to the remote's default branch after fetching to ensure directory listings resolve

## Testing
- `cargo check --manifest-path server/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68da62a90950833187ba67bd0fef3af7